### PR TITLE
Bug Fix #1: Error statement in subtitle.

### DIFF
--- a/currency-converter/src/app/landing-page/landing-page.component.html
+++ b/currency-converter/src/app/landing-page/landing-page.component.html
@@ -10,7 +10,7 @@
     <div class="one column"></div>
     <div class="eleven columns" id="subtitle-holder-div">
       This is a very simple to use currency converter, doing what a currency converter must do.
-      <br />Except this one keeps updating itself using an RSS feed. Cause hey, who likes a currency converter who uses rates of the past?
+      <br />Except this one keeps updating itself using an RSS feed. Cause hey, who likes a currency converter which uses rates of the past?
       <br />Furthermore, there's a table below which shows the rates of the 5 most widely used currencies and another one below it which shows the rates of your selected currency compared to all the currencies in the world.
       <br /><br />So, you never, ever miss out on anything.
     </div>


### PR DESCRIPTION
# Error fix for subtitle sentence
#1 features a sentence in the second sentence of the second line in the subtitle:

> Cause hey, who likes a currency converter _who_ uses rates of the past?

So, as it can be very well seen that the converter is a non-living thing, so grammatically, the _who_ is wrong.
This has been changed to:

> Cause hey, who likes a currency converter _which_ uses rates of the past?
